### PR TITLE
Add typeorm

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach NestJS WS",
+      "port": 9229,
+      "restart": true,
+      "stopOnEntry": false,
+      "protocol": "inspector"
+    }
+  ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:11.9.0 as builder
+
+WORKDIR /builder
+COPY . .
+RUN npm install
+RUN npm run build
+
+FROM node:11.9.0 as runtime
+
+WORKDIR /app
+
+COPY --from=builder "/builder/dist/"               "/app/dist/"
+COPY --from=builder "/builder/node_modules/"       "/app/node_modules/"
+COPY --from=builder "/builder/ormconfig-prod.json" "/app/ormconfig.json"
+COPY --from=builder "/builder/.env"                "/app/.env"
+
+EXPOSE 3000
+
+CMD ["node","dist/main"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,26 @@ IPFS_PORT=5001
 
 ## Running the app
 
+### Requirements
+
+- node `v11.9.0`
+- docker v19 (working with `Docker version 19.03.5, build 633a0ea838`)
+- docker-compose v1 (working with `docker-compose version 1.22.0, build f46880fe`)
+
 ```bash
+# to use the correct node version
+nvm use v11.9.0
+
+# or as of now (2020/01/15), stable version points to v11.9.0
+nvm use stable
+```
+
+### Development mode
+
+```bash
+# make sure the databse is up and running
+$ docker-compose up
+
 # development
 $ npm run start
 
@@ -29,7 +48,44 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
-In development mode (`npm run start:dev`), Swagger endpoint should be accessible: http://localhost:3000/api/#
+Swagger endpoint should be accessible: http://localhost:3000/api/#
+
+### Prod mode - single node
+
+```bash
+# use docker-compose-single-node
+# 1) brings up postgres db
+# 2) brings up ekho instance
+$ docker-compose -f docker-compose-single-node.yml up
+
+# to update existing containers with new code, rebuild new images
+$ docker-compose -f docker-compose-single-node.yml down
+$ docker-compose -f docker-compose-single-node.yml build
+$ docker-compose -f docker-compose-single-node.yml up
+```
+
+Swagger endpoint should be accessible: http://localhost:3000/api/#
+
+### Prod mode - dual node
+
+```bash
+# use docker-compose-dual-node
+# 1) brings up postgres db1 and ekho1 in network1
+# 2) brings up postgres db2 and ekho2 in network2
+# Note: instance 1 and 2 are isolated by different networks
+$ docker-compose -f docker-compose-dual-node.yml up
+
+# to update existing containers with new code, rebuild new images
+$ docker-compose -f docker-compose-dual-node.yml down
+$ docker-compose -f docker-compose-dual-node.yml build
+$ docker-compose -f docker-compose-dual-node.yml up
+```
+
+Swagger endpoints should be accessible:
+- http://localhost:3100/api/#
+- http://localhost:3200/api/#
+
+Note: single and dual node can run simultaneosly, producing 3 separate instances locally
 
 ## Test
 

--- a/docker-compose-dual-node.yml
+++ b/docker-compose-dual-node.yml
@@ -1,0 +1,52 @@
+---
+version: "3.7"
+services:
+    ekho1:
+        build: 
+            context: .
+            dockerfile: Dockerfile
+        ports:
+            - 3100:3000
+        networks:
+            - network1
+    db1:
+        image: docker.io/postgres:11.6-alpine
+        restart: always
+        environment:
+            - POSTGRES_USER=ekho
+            - POSTGRES_PASSWORD=ekho
+            - POSTGRES_DB=ekho
+        volumes:
+            - ekho-db1:/var/lib/postgresql/data
+        networks:
+            network1:
+                aliases:
+                    - db
+    ekho2:
+        build: 
+            context: .
+            dockerfile: Dockerfile
+        ports:
+            - 3200:3000
+        networks:
+            - network2
+    db2:
+        image: docker.io/postgres:11.6-alpine
+        restart: always
+        environment:
+            - POSTGRES_USER=ekho
+            - POSTGRES_PASSWORD=ekho
+            - POSTGRES_DB=ekho
+        volumes:
+            - ekho-db2:/var/lib/postgresql/data
+        networks:
+            network2:
+                aliases:
+                    - db
+volumes: 
+    ekho-db1:
+    ekho-db2:
+
+networks:
+    network1:
+    network2:

--- a/docker-compose-single-node.yml
+++ b/docker-compose-single-node.yml
@@ -1,0 +1,29 @@
+---
+version: "3.7"
+services:
+    ekho:
+        build: 
+            context: .
+            dockerfile: Dockerfile
+        ports:
+            - 3000:3000
+        networks:
+            - network
+    db:
+        image: docker.io/postgres:11.6-alpine
+        restart: always
+        environment:
+            - POSTGRES_USER=ekho
+            - POSTGRES_PASSWORD=ekho
+            - POSTGRES_DB=ekho
+        volumes:
+            - ekho-db0:/var/lib/postgresql/data
+        networks:
+            network:
+                aliases:
+                    - db
+volumes: 
+    ekho-db0:
+
+networks:
+    network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+version: "3.7"
+services:
+    db:
+        image: docker.io/postgres:11.6-alpine
+        restart: always
+        ports: 
+            - 5432:5432
+        environment:
+            - POSTGRES_USER=ekho
+            - POSTGRES_PASSWORD=ekho
+            - POSTGRES_DB=ekho
+        volumes:
+            - ekho-db:/var/lib/postgresql/data
+volumes: 
+    ekho-db:

--- a/ormconfig-prod.json
+++ b/ormconfig-prod.json
@@ -1,0 +1,11 @@
+{
+    "type": "postgres",
+    "host": "db",
+    "port": 5432,
+    "username": "ekho",
+    "password": "ekho",
+    "database": "ekho",
+    "entities": ["dist/**/*.entity{.ts,.js}"],
+    "synchronize": true,
+    "logging" : true
+  }

--- a/ormconfig.json
+++ b/ormconfig.json
@@ -1,0 +1,11 @@
+{
+    "type": "postgres",
+    "host": "localhost",
+    "port": 5432,
+    "username": "ekho",
+    "password": "ekho",
+    "database": "ekho",
+    "entities": ["dist/**/*.entity{.ts,.js}"],
+    "synchronize": true,
+    "logging" : true
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -665,6 +665,14 @@
         "optional": "0.1.4"
       }
     },
+    "@nestjs/typeorm": {
+      "version": "6.2.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/@nestjs/typeorm/-/typeorm-6.2.0.tgz",
+      "integrity": "sha512-CRDYV3oxTUa6mTDJfdW+RPLtVUpGx0RpigQdLlvMFLM56v+bYnrTuuy4vurKDgLNFC+AttL9JLZOgRhW8fGdgQ==",
+      "requires": {
+        "uuid": "3.3.3"
+      }
+    },
     "@nuxtjs/opencollective": {
       "version": "0.2.2",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/@nuxtjs/opencollective/-/opencollective-0.2.2.tgz",
@@ -774,8 +782,7 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/connect": {
       "version": "3.4.33",
@@ -1323,6 +1330,11 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "app-root-path": {
+      "version": "3.0.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/app-root-path/-/app-root-path-3.0.0.tgz",
+      "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw=="
+    },
     "append-field": {
       "version": "1.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/append-field/-/append-field-1.0.0.tgz",
@@ -1344,7 +1356,6 @@
       "version": "1.0.10",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -2021,6 +2032,11 @@
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
       "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo="
     },
+    "buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -2146,8 +2162,7 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -2300,6 +2315,180 @@
         "restore-cursor": "^2.0.0"
       }
     },
+    "cli-highlight": {
+      "version": "2.1.4",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/cli-highlight/-/cli-highlight-2.1.4.tgz",
+      "integrity": "sha512-s7Zofobm20qriqDoU9sXptQx0t2R9PEgac92mENNm7xaEe1hn71IIMsXMK+6encA6WRCWWxIGQbipr3q998tlQ==",
+      "requires": {
+        "chalk": "^3.0.0",
+        "highlight.js": "^9.6.0",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^5.1.1",
+        "yargs": "^15.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.1.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/yargs/-/yargs-15.1.0.tgz",
+          "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^16.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "16.1.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "cli-spinners": {
       "version": "2.2.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/cli-spinners/-/cli-spinners-2.2.0.tgz",
@@ -2327,7 +2516,6 @@
       "version": "5.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dev": true,
       "requires": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -2338,7 +2526,6 @@
           "version": "3.1.0",
           "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -2719,8 +2906,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -3094,8 +3280,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -3797,6 +3982,11 @@
       "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
       "dev": true
     },
+    "figlet": {
+      "version": "1.2.4",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/figlet/-/figlet-1.2.4.tgz",
+      "integrity": "sha512-mv8YA9RruB4C5QawPaD29rEVx3N97ZTyNrE4DAfbhuo6tpcMdKnPVo8MlyT3RP5uPcg5M14bEJBq7kjFf4kAWg=="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/figures/-/figures-2.0.0.tgz",
@@ -3878,7 +4068,6 @@
       "version": "3.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
       }
@@ -4260,8 +4449,7 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4421,7 +4609,6 @@
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4440,7 +4627,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4543,7 +4729,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4665,7 +4850,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4746,8 +4930,7 @@
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-iterator": {
       "version": "1.0.2",
@@ -4870,7 +5053,6 @@
       "version": "4.6.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/handlebars/-/handlebars-4.6.0.tgz",
       "integrity": "sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==",
-      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -4881,8 +5063,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -4913,7 +5094,6 @@
       "version": "2.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -5002,6 +5182,14 @@
       "version": "0.5.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/hi-base32/-/hi-base32-0.5.0.tgz",
       "integrity": "sha512-DDRmxSyoYuvjUb9EnXdoiMChBZ7ZcUVJsK5Frd3kqMhuBxvmZdnBeynAVfj7/ECbn++CekcoprvC/rprHPAtow=="
+    },
+    "highlight.js": {
+      "version": "9.17.1",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/highlight.js/-/highlight.js-9.17.1.tgz",
+      "integrity": "sha512-TA2/doAur5Ol8+iM3Ov7qy3jYcr/QiJ2eDTdRF4dfbjG7AaaB99J5G+zSl11ljbl6cIcahgPY6SKb3sC3EJ0fw==",
+      "requires": {
+        "handlebars": "^4.5.3"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -5630,8 +5818,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-function": {
       "version": "1.0.1",
@@ -6558,7 +6745,6 @@
       "version": "3.13.1",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -6567,8 +6753,7 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
         }
       }
     },
@@ -6899,7 +7084,6 @@
       "version": "3.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -7506,6 +7690,16 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/nan/-/nan-2.14.0.tgz",
@@ -7549,8 +7743,7 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "next-tick": {
       "version": "1.0.0",
@@ -7938,7 +8131,6 @@
       "version": "0.6.1",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -8146,7 +8338,6 @@
       "version": "2.2.2",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/p-limit/-/p-limit-2.2.2.tgz",
       "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -8155,7 +8346,6 @@
       "version": "3.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
       }
@@ -8177,8 +8367,12 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
     "pako": {
       "version": "1.0.10",
@@ -8229,6 +8423,11 @@
         }
       }
     },
+    "parent-require": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/parent-require/-/parent-require-1.0.0.tgz",
+      "integrity": "sha1-dGoWdjgIOoYLDu9nMssn7UbDKXc="
+    },
     "parse-asn1": {
       "version": "5.1.5",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -8268,6 +8467,21 @@
       "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
       "dev": true
     },
+    "parse5-htmlparser2-tree-adapter": {
+      "version": "5.1.1",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-5.1.1.tgz",
+      "integrity": "sha512-CF+TKjXqoqyDwHqBhFQ+3l5t83xYi6fVT1tQNg+Ye0JRLnTxWvIroCjEp1A0k4lneHNBGnICUf0cfYVYGEazqw==",
+      "requires": {
+        "parse5": "^5.1.1"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+        }
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/parseurl/-/parseurl-1.3.3.tgz",
@@ -8294,8 +8508,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -8411,6 +8624,68 @@
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pg": {
+      "version": "7.17.1",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/pg/-/pg-7.17.1.tgz",
+      "integrity": "sha512-SYWEip6eADsgDQIZk0bmB2JDOrC8Xu6z10KlhlXl03NSomwVmHB6ZTVyDCwOfT6bXHI8QndJdk5XxSSRXikaSA==",
+      "requires": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "0.1.3",
+        "pg-packet-stream": "^1.1.0",
+        "pg-pool": "^2.0.9",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x",
+        "semver": "4.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.2",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/semver/-/semver-4.3.2.tgz",
+          "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+        }
+      }
+    },
+    "pg-connection-string": {
+      "version": "0.1.3",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+    },
+    "pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
+    },
+    "pg-packet-stream": {
+      "version": "1.1.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/pg-packet-stream/-/pg-packet-stream-1.1.0.tgz",
+      "integrity": "sha512-kRBH0tDIW/8lfnnOyTwKD23ygJ/kexQVXZs7gEyBljw4FYqimZFxnMMx50ndZ8In77QgfGuItS5LLclC2TtjYg=="
+    },
+    "pg-pool": {
+      "version": "2.0.9",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/pg-pool/-/pg-pool-2.0.9.tgz",
+      "integrity": "sha512-gNiuIEKNCT3OnudQM2kvgSnXsLkSpd6mS/fRnqs6ANtrke6j8OY5l9mnAryf1kgwJMWLg0C1N1cYTZG1xmEYHQ=="
+    },
+    "pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "requires": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      }
+    },
+    "pgpass": {
+      "version": "1.0.2",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/pgpass/-/pgpass-1.0.2.tgz",
+      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+      "requires": {
+        "split": "^1.0.0"
+      }
+    },
     "picomatch": {
       "version": "2.2.1",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/picomatch/-/picomatch-2.2.1.tgz",
@@ -8465,6 +8740,29 @@
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
+    },
+    "postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+    },
+    "postgres-date": {
+      "version": "1.0.4",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/postgres-date/-/postgres-date-1.0.4.tgz",
+      "integrity": "sha512-bESRvKVuTrjoBluEcpv2346+6kgB7UlnqWZsnbnCccTNq/pqfj1j6oBaN5+b/NrDXepYUT/HKadqv3iS9lJuVA=="
+    },
+    "postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "requires": {
+        "xtend": "^4.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -8903,14 +9201,12 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "resolve": {
       "version": "1.14.2",
@@ -9104,8 +9400,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "schema-utils": {
       "version": "1.0.0",
@@ -9241,8 +9536,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.1",
@@ -9567,6 +9861,14 @@
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/split-string/-/split-string-3.1.0.tgz",
@@ -9579,8 +9881,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -9846,7 +10147,6 @@
       "version": "5.2.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^4.1.0"
       },
@@ -9854,8 +10154,7 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         }
       }
     },
@@ -10201,6 +10500,22 @@
         "minimatch": "^3.0.4",
         "read-pkg-up": "^4.0.0",
         "require-main-filename": "^2.0.0"
+      }
+    },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
       }
     },
     "throat": {
@@ -10656,6 +10971,56 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typeorm": {
+      "version": "0.2.22",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/typeorm/-/typeorm-0.2.22.tgz",
+      "integrity": "sha512-mDEnMtzRwX4zMYbyzM9xDn7jvGs8hfQ2ymOBq36Zxq1RVM642numwlRbr4W8dU7ZYx8CQUE9rmk+sU0baHD9Rw==",
+      "requires": {
+        "app-root-path": "^3.0.0",
+        "buffer": "^5.1.0",
+        "chalk": "^2.4.2",
+        "cli-highlight": "^2.0.0",
+        "debug": "^4.1.1",
+        "dotenv": "^6.2.0",
+        "glob": "^7.1.2",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "^0.5.1",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^1.9.0",
+        "xml2js": "^0.4.17",
+        "yargonaut": "^1.1.2",
+        "yargs": "^13.2.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "dotenv": {
+          "version": "6.2.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/dotenv/-/dotenv-6.2.0.tgz",
+          "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "typescript": {
       "version": "3.7.4",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/typescript/-/typescript-3.7.4.tgz",
@@ -10666,7 +11031,6 @@
       "version": "3.7.4",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/uglify-js/-/uglify-js-3.7.4.tgz",
       "integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.3",
@@ -10677,14 +11041,12 @@
           "version": "2.20.3",
           "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
           "optional": true
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
@@ -11443,8 +11805,7 @@
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
     "windows-release": {
       "version": "3.2.0",
@@ -11488,7 +11849,6 @@
       "version": "5.1.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -11499,7 +11859,6 @@
           "version": "3.1.0",
           "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -11580,6 +11939,20 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
@@ -11593,8 +11966,7 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yaeti": {
       "version": "0.0.6",
@@ -11606,11 +11978,52 @@
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
+    "yargonaut": {
+      "version": "1.1.4",
+      "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/yargonaut/-/yargonaut-1.1.4.tgz",
+      "integrity": "sha512-rHgFmbgXAAzl+1nngqOcwEljqHGG9uUZoPjsdZEs1w5JW9RXYzrSvH/u70C1JE5qFi0qjsdhnUX/dJRpWqitSA==",
+      "requires": {
+        "chalk": "^1.1.1",
+        "figlet": "^1.1.1",
+        "parent-require": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
     "yargs": {
       "version": "13.3.0",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/yargs/-/yargs-13.3.0.tgz",
       "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-      "dev": true,
       "requires": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -11628,7 +12041,6 @@
           "version": "3.1.0",
           "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -11641,7 +12053,6 @@
       "version": "13.1.1",
       "resolved": "https://nexus.solutions.consensys-uk.net/repository/komgo-npm-group/yargs-parser/-/yargs-parser-13.1.1.tgz",
       "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-      "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -25,13 +25,16 @@
     "@nestjs/core": "^6.7.2",
     "@nestjs/platform-express": "^6.7.2",
     "@nestjs/swagger": "^4.1.7",
+    "@nestjs/typeorm": "^6.2.0",
     "ethereumjs-tx": "^2.1.2",
     "ipfs-http-client": "^40.2.1",
+    "pg": "^7.17.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.0",
     "rxjs": "^6.5.3",
     "sodium-native": "^2.4.6",
     "swagger-ui-express": "^4.1.2",
+    "typeorm": "^0.2.22",
     "web3": "^1.2.4"
   },
   "devDependencies": {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,16 +1,19 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { CryptographyModule } from './cryptography/cryptography.module';
 import ipfsConfiguration from './ipfs/ipfs.configuration';
 import { Web3Module } from './web3/web3.module';
 import { IpfsModule } from './ipfs/ipfs.module';
+import { UsersModule } from './users/users.module';
+import { MessagesModule } from './messages/messages.module';
 import web3Configuration from './web3/web3.configuration';
 
 @Module({
-  imports: [ConfigModule.forRoot({
+  imports: [TypeOrmModule.forRoot(), ConfigModule.forRoot({
     isGlobal: true,
     load: [ipfsConfiguration, web3Configuration],
-  }), CryptographyModule, Web3Module, IpfsModule],
+  }), CryptographyModule, Web3Module, IpfsModule, UsersModule, MessagesModule],
   controllers: [],
   providers: [],
 })

--- a/src/ipfs/dto/ipfs-message.dto.ts
+++ b/src/ipfs/dto/ipfs-message.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class IpfsMessageDto {
-    @ApiProperty({ description: 'Message' })
-    message: string;
+    @ApiProperty({ description: 'From' })
+    from: string;
+
+    @ApiProperty({ description: 'To' })
+    to: string;
+
+    @ApiProperty({ description: 'Content' })
+    content: string;
 }

--- a/src/ipfs/ipfs.module.ts
+++ b/src/ipfs/ipfs.module.ts
@@ -7,5 +7,6 @@ import { IpfsService } from './ipfs.service';
     imports: [ConfigModule],
     providers: [IpfsService],
     controllers: [IpfsController],
+    exports: [IpfsService],
 })
 export class IpfsModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { ConfigService } from '@nestjs/config';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);

--- a/src/messages/dto/send-message.dto.ts
+++ b/src/messages/dto/send-message.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export default class SendMessageDto {
+  @ApiProperty({ description: 'From' })
+  from: string;
+
+  @ApiProperty({ description: 'To' })
+  to: string;
+
+  @ApiProperty({ description: 'Content' })
+  content: string;
+
+  // TODO: for now exposing the channel id for simplicity; this will be calculated internally in the future
+  @ApiProperty({ description: 'Channel ID' })
+  channelId: string;
+}

--- a/src/messages/messages.controller.spec.ts
+++ b/src/messages/messages.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessagesController } from './messages.controller';
+
+describe('Messages Controller', () => {
+  let controller: MessagesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MessagesController],
+    }).compile();
+
+    controller = module.get<MessagesController>(MessagesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/messages/messages.controller.ts
+++ b/src/messages/messages.controller.ts
@@ -1,0 +1,36 @@
+import { Controller, Post, Body, Query, Get, Param } from '@nestjs/common';
+import SendMessageDto from './dto/send-message.dto';
+import { MessagesService } from './messages.service';
+import { Message } from './messages.entity';
+
+@Controller('messages')
+export class MessagesController {
+  constructor(
+    private readonly messagesService: MessagesService) { }
+  @Post()
+  async sendMessage(@Body() message: SendMessageDto): Promise<void> {
+    await this.messagesService.sendMessage(message.from, message.to, message.channelId, message.content);
+  }
+
+  @Get()
+  async getAllMessages(): Promise<Message[]> {
+    return this.messagesService.findAll();
+  }
+
+  @Get('/:user')
+  async getMessages(@Param('user') user: string): Promise<Message[]> {
+    const messages: Message[] = [];
+    // TODO: for now we're just simulating a sequence of channel id
+    //       example: ['bob-1', 'bob-2', 'bob-3', ...]
+    let i = 1;
+    while(true) {
+      const message = await this.messagesService.findForUser(user, `${user}-${i++}`);
+      if (message) {
+        messages.push(message);
+      } else {
+        break;
+      }
+    }
+    return messages;
+  }
+}

--- a/src/messages/messages.entity.ts
+++ b/src/messages/messages.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, Column, PrimaryGeneratedColumn, Unique } from 'typeorm';
+
+@Entity()
+@Unique('UQ_USER_CHANNELID', ['to', 'channelId'])
+export class Message {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  timestamp: Date;
+
+  @Column()
+  from: string;
+
+  @Column()
+  to: string;
+
+  @Column()
+  content: string;
+
+  @Column()
+  ipfsPath: string;
+
+  @Column()
+  txHash: string;
+
+  @Column()
+  channelId: string;
+}

--- a/src/messages/messages.module.ts
+++ b/src/messages/messages.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { MessagesController } from './messages.controller';
+import { MessagesService } from './messages.service';
+import { IpfsModule } from '../ipfs/ipfs.module';
+import { Web3Module } from '../web3/web3.module';
+import { Message } from './messages.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Message]), IpfsModule, Web3Module],
+  controllers: [MessagesController],
+  providers: [MessagesService],
+})
+export class MessagesModule {}

--- a/src/messages/messages.service.spec.ts
+++ b/src/messages/messages.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessagesService } from './messages.service';
+
+describe('MessagesService', () => {
+  let service: MessagesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MessagesService],
+    }).compile();
+
+    service = module.get<MessagesService>(MessagesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Message } from './messages.entity';
+import { Repository } from 'typeorm';
+import { IpfsService } from '../ipfs/ipfs.service';
+import { Web3Service } from '../web3/web3.service';
+import SendMessageDto from './dto/send-message.dto';
+
+@Injectable()
+export class MessagesService {
+  constructor(
+    @InjectRepository(Message)
+    private readonly messageRepository: Repository<Message>,
+    private readonly ipfsService: IpfsService,
+    private readonly web3Service: Web3Service,
+  ) {}
+
+  async sendMessage(from: string, to: string, channelId: string, content: string): Promise<void> {
+    const ipfsPath: string = await this.ipfsService.store({ to, from, content });
+    Logger.debug(ipfsPath);
+    const txHash: string = await this.web3Service.broadcastNotification(channelId, ipfsPath, '');
+    Logger.debug(txHash);
+
+    const message = new Message();
+    message.timestamp = new Date();
+    message.from = from;
+    message.to = to;
+    message.content = content;
+    message.ipfsPath = ipfsPath;
+    message.txHash = txHash;
+    message.channelId = channelId;
+    // TODO: need to rethink this part
+    // await this.messageRepository.save(message);
+  }
+
+  async findAll(): Promise<Message[]> {
+    return await this.messageRepository.find();
+  }
+
+  async findForUser(user: string, channelId: string): Promise<Message> {
+    // getting messages for alice
+    // calculate next channelId
+
+    // check if message is already in the repository
+    let message = await this.messageRepository.findOne({ where: { to: user, channelId }});
+    if (message) {
+      return message;
+    }
+
+    // given message is not in the repository, check if received transactions contain the channel id
+    // if not, simply return nothing
+    // if yes, extract the message and save it in the repository
+    const tx = await this.web3Service.getTransactionByChannelId(channelId);
+    if (!tx) {
+      return null;
+    }
+
+    const storedMessage = await this.ipfsService.retrieve(tx.content);
+    message = new Message();
+    message.from = storedMessage.from;
+    message.to = storedMessage.to;
+    message.content = storedMessage.content;
+    message.ipfsPath = tx.content;
+    message.txHash = tx.txHash;
+    message.channelId = channelId;
+    message.timestamp = tx.createdDate;
+    await this.messageRepository.save(message);
+
+    return this.messageRepository.findOne({ where: { channelId }});
+  }
+}

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export default class CreateUserDto {
+  @ApiProperty({ description: 'User name' })
+  name: string;
+}

--- a/src/users/dto/user.dto.ts
+++ b/src/users/dto/user.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export default class UserDto {
+  @ApiProperty({ description: 'User name' })
+  name: string;
+}

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+
+describe('Users Controller', () => {
+  let controller: UsersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UsersController],
+    }).compile();
+
+    controller = module.get<UsersController>(UsersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Post, Body, Get, Query } from '@nestjs/common';
+import CreateUserDto from './dto/create-user.dto';
+import { UsersService } from './users.service';
+import UserDto from './dto/user.dto';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly userService: UsersService) {}
+
+  @Post()
+  async create(@Body() user: CreateUserDto): Promise<void> {
+    this.userService.create(user);
+  }
+
+  @Get()
+  async get(@Query('name') name: string): Promise<UserDto> {
+    return this.userService.findByName(name);
+  }
+}

--- a/src/users/users.entity.ts
+++ b/src/users/users.entity.ts
@@ -1,0 +1,11 @@
+import { Entity, Column, PrimaryGeneratedColumn, Unique } from 'typeorm';
+
+@Entity()
+@Unique('UQ_NAME', ['name'])
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 500 })
+  name: string;
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './users.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  providers: [UsersService],
+  controllers: [UsersController]
+})
+export class UsersModule {}

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UsersService } from './users.service';
+
+describe('UsersService', () => {
+  let service: UsersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UsersService],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import CreateUserDto from './dto/create-user.dto';
+import { User } from './users.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import UserDto from './dto/user.dto';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  async create(user: CreateUserDto): Promise<void> {
+    const newUser = new User();
+    newUser.name = user.name;
+    // newUser.privateKey = this.cryptographyService.generatePrivateKey()
+    await this.userRepository.save(newUser);
+  }
+
+  async findByName(name: string): Promise<UserDto> {
+    return this.userRepository.findOne({
+      select: ['name'],
+      where: { name }});
+  }
+}

--- a/src/web3/web3.constants.ts
+++ b/src/web3/web3.constants.ts
@@ -1,32 +1,54 @@
 export const Web3Constants = {
     abi: [
         {
-            'constant': false,
-            'inputs': [
+            "anonymous": false,
+            "inputs": [
                 {
-                    'internalType': 'string',
-                    'name': 'messageUid',
-                    'type': 'string'
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "channelId",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "content",
+                    "type": "string"
+                },
+                {
+                    "indexed": false,
+                    "internalType": "string",
+                    "name": "signature",
+                    "type": "string"
                 }
             ],
-            'name': 'notify',
-            'outputs': [],
-            'payable': false,
-            'stateMutability': 'nonpayable',
-            'type': 'function',
+            "name": "NotifyNewMessage",
+            "type": "event"
         },
         {
-            'anonymous': false,
-            'inputs': [
+            "constant": false,
+            "inputs": [
                 {
-                    'indexed': false,
-                    'internalType': 'string',
-                    'name': 'messageUid',
-                    'type': 'string',
+                    "internalType": "string",
+                    "name": "channelId",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "content",
+                    "type": "string"
+                },
+                {
+                    "internalType": "string",
+                    "name": "signature",
+                    "type": "string"
                 }
             ],
-            'name': 'NotifyNewMessage',
-            'type': 'event',
-        },
-    ],
+            "name": "notify",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        }
+    ]
 };

--- a/src/web3/web3.controller.ts
+++ b/src/web3/web3.controller.ts
@@ -1,12 +1,19 @@
-import { Controller, Post, Param } from '@nestjs/common';
+import { Controller, Post, Param, Get } from '@nestjs/common';
 import { Web3Service } from './web3.service';
+import { Web3Transaction } from './web3.entity';
 
 @Controller('web3')
 export class Web3Controller {
     constructor(private readonly web3Service: Web3Service) {}
 
-    @Post(':message')
-    async post(@Param('message') message: string): Promise<string> {
-        return this.web3Service.broadcastNotification(message);
+    @Get()
+    async get(): Promise<Web3Transaction[]> {
+        return this.web3Service.getAll();
+    }
+
+    // TODO: do not be lazy and use a proper dto
+    @Post(':channel-id/:content/:signature')
+    async post(@Param('channel-id') channelId: string, @Param('content') content: string, @Param('signature') signature: string): Promise<string> {
+        return this.web3Service.broadcastNotification(channelId, content, signature);
     }
 }

--- a/src/web3/web3.entity.ts
+++ b/src/web3/web3.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, Column, PrimaryGeneratedColumn, Unique, CreateDateColumn } from 'typeorm';
+
+@Entity()
+@Unique('UQ_TX_HASH', ['txHash'])
+export class Web3Transaction {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  txHash: string;
+
+  @Column()
+  status: string;
+
+  @Column({ nullable: true})
+  channelId?: string;
+
+  @Column({ nullable: true})
+  content?: string;
+
+  @Column({ nullable: true})
+  signature?: string;
+
+  @CreateDateColumn()
+  createdDate: Date;
+}

--- a/src/web3/web3.factory.ts
+++ b/src/web3/web3.factory.ts
@@ -1,0 +1,7 @@
+import Web3 from 'web3';
+
+export class Web3Factory {
+  getWeb3(rpcUrl: string): Web3 {
+    return new Web3(new Web3.providers.WebsocketProvider(rpcUrl));
+  }
+}

--- a/src/web3/web3.module.ts
+++ b/src/web3/web3.module.ts
@@ -2,10 +2,14 @@ import { Module } from '@nestjs/common';
 import { Web3Controller } from './web3.controller';
 import { Web3Service } from './web3.service';
 import { ConfigModule } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Web3Transaction } from './web3.entity';
+import { Web3Factory } from './web3.factory';
 
 @Module({
-  imports: [ConfigModule],
+  imports: [TypeOrmModule.forFeature([Web3Transaction]), ConfigModule],
   controllers: [Web3Controller],
-  providers: [Web3Service],
+  providers: [Web3Service, Web3Factory],
+  exports: [Web3Service]
 })
 export class Web3Module {}

--- a/src/web3/web3.service.spec.ts
+++ b/src/web3/web3.service.spec.ts
@@ -1,12 +1,29 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { Web3Service } from './web3.service';
+import { Web3Transaction } from './web3.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import Web3 from 'web3';
+import {Web3Constants} from './web3.constants';
+import { Web3Factory } from './web3.factory';
 
 describe('Web3Service', () => {
   let service: Web3Service;
+  const transactionRepository = jest.fn(() => ({
+    metadata: {
+      columns: [],
+      relations: [],
+    },
+  }));
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [Web3Service],
+      providers: [Web3Service,
+        {
+          provide: getRepositoryToken(Web3Transaction),
+          useValue: transactionRepository,
+        },
+      ConfigService, Web3Factory],
     }).compile();
 
     service = module.get<Web3Service>(Web3Service);
@@ -14,5 +31,23 @@ describe('Web3Service', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('should persist listened message', () => {
+    const blockchainMessage = {
+        removed: false,
+        logIndex: 0,
+        transactionIndex: 1,
+        transactionHash: '0x10f491686c7d6fdc9932dfc3af89c67f933c2712356161ec0100c91812c98110',
+        blockHash: '0xce42e63088fd54b774f6f63e2d455f7ba8ba6beef2ae2717296810912dc33ce5',
+        blockNumber: 7124238,
+        address: '0x685d084000deE51bEb11A32009c1CFE189f78754',
+        data: '0x000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000043078303000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a3078373436353733373400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a3078373436353733373400000000000000000000000000000000000000000000',
+        topics: [
+          '0xcc0c43f8734c63f9e35eaa597a582ed47e1ff597944f4cb974defa48e712f3a7'
+        ],
+        id: 'log_2d5620aa'
+      };
+    // TBD
   });
 });

--- a/src/web3/web3.service.ts
+++ b/src/web3/web3.service.ts
@@ -5,6 +5,10 @@ import { bufferToHex } from 'ethereumjs-util';
 import { ConfigService } from '@nestjs/config';
 
 import {Web3Constants} from './web3.constants';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, getConnection } from 'typeorm';
+import { Web3Transaction } from './web3.entity';
+import { Web3Factory } from './web3.factory';
 
 @Injectable()
 export class Web3Service {
@@ -34,7 +38,11 @@ export class Web3Service {
     private readonly publicKey;
     private readonly web3;
 
-    constructor(private readonly configService: ConfigService) {
+    constructor(
+        @InjectRepository(Web3Transaction)
+        private readonly transactionsRepository: Repository<Web3Transaction>,
+        private readonly configService: ConfigService,
+        private readonly web3Factory: Web3Factory) {
         this.chain = this.configService.get<string>('web3.chain');
         this.hardfork = this.configService.get<string>('web3.hardfork');
         this.rpcUrl = this.configService.get<string>('web3.rpcUrl');
@@ -42,13 +50,10 @@ export class Web3Service {
         this.address = this.configService.get<string>('web3.broadcastAccount.address');
         this.publicKey = this.configService.get<string>('web3.broadcastAccount.publicKey');
         this.privateKey = this.configService.get<string>('web3.broadcastAccount.privateKey');
-
-        this.web3 = new Web3(new Web3.providers.WebsocketProvider(this.rpcUrl));
-        this.initListener();
+        this.web3 = web3Factory.getWeb3(this.rpcUrl);
     }
 
-    // POC - just logging event sent to this contract
-    private initListener() {
+    async onModuleInit(): Promise<void> {
         const options = {
             fromBlock: 0,
             address: this.contractAddress,
@@ -57,24 +62,54 @@ export class Web3Service {
             if (error) {
                 Logger.error(result);
             }
-        }).on('data', log => {
-            Logger.debug(log);
-            Logger.debug(`Data received from logs: ${this.web3.utils.hexToUtf8(log.data)}`);
+        }).on('data', async log => {
+            const transactionHash = log.transactionHash;
+            Logger.debug(`Received raw event: '${JSON.stringify(log, null, 2)}'`, transactionHash);
+            const decoded = this.web3.eth.abi.decodeParameters(['string', 'string', 'string'], log.data);
+            const channelId = Web3.utils.toUtf8(decoded[0]);
+            const content = Web3.utils.toUtf8(decoded[1]);
+            const signature = Web3.utils.toUtf8(decoded[2]);
+            Logger.debug(`parsed channelId='${channelId}'`, transactionHash);
+            Logger.debug(`parsed   content='${content}'`, transactionHash);
+            Logger.debug(`parsed signature='${signature}'`, transactionHash);
+            let tx = await this.transactionsRepository.findOne({ txHash: transactionHash });
+            if (!tx) {
+                tx = new Web3Transaction();
+            }
+            tx.txHash = transactionHash;
+            tx.channelId = channelId;
+            tx.content = content;
+            tx.signature = signature;
+            tx.status = 'confirmed';
+            await this.transactionsRepository.save(tx);
         }).on('changed', log => {
             Logger.debug(log);
         });
+        Logger.debug(`Subcribed logs from ${this.contractAddress} via ${this.rpcUrl}`);
+      }
+
+    async getAll(): Promise<Web3Transaction[]> {
+        return this.transactionsRepository.find();
     }
 
-    async broadcastNotification(messageUid: string): Promise<string> {
+    async getTransactionByChannelId(channelId: string): Promise<Web3Transaction> {
+        return this.transactionsRepository.findOne({ where: { channelId }});
+    }
+
+    async broadcastNotification(channelId: string, content: string, signature: string): Promise<string> {
             const txCount = await this.getTransactionCount(this.address);
             Logger.debug(`TransactionCount: ${txCount}`);
             const bufferedPrivateKey = Buffer.from(this.privateKey, 'hex');
             const contract = new this.web3.eth.Contract(Web3Constants.abi, this.contractAddress);
-            const data = contract.methods.notify(messageUid).encodeABI();
+            const data = contract.methods.notify(
+                Web3.utils.fromAscii(channelId),
+                Web3.utils.fromAscii(content),
+                Web3.utils.fromAscii(signature),
+            ).encodeABI();
             const txObject = {
                 nonce: this.web3.utils.toHex(txCount),
                 gasLimit: this.web3.utils.toHex(800000),
-                gasPrice: this.web3.utils.toHex(this.web3.utils.toWei('10', 'gwei')),
+                gasPrice: this.web3.utils.toHex(this.web3.utils.toWei('15', 'gwei')),
                 to: this.contractAddress,
                 data,
             };
@@ -95,7 +130,9 @@ export class Web3Service {
             const serializedTx = tx.serialize();
             const raw = '0x' + serializedTx.toString('hex');
 
-            return this.sendSignerTransaction(raw);
+            const txHash = await this.sendSignerTransaction(raw);
+            await this.transactionsRepository.save({txHash, status: 'pending'});
+            return txHash;
     }
 
     async getTransactionCount(account: string) {


### PR DESCRIPTION
Add postgres, docker/docker-compose and new message and users modules

new messages module
- allows sending messages and retrieving messages via REST API
- persists messages in database

new users module
- allows storing and retrieving users to/from the database

web3 module and smart contract
- smart contract now requires 3 arguments: channelId, content and signature
- web3 service was updated to accomodate these changes
 - when broadcasting an event
 - when listening to events
- add new entity Web3Transaction which persists events emitted in our contract
- add Web3Factory to help building unit tests

docker
- add Dockerfile which creates a docker image with current code production build
- add docker-compose-single-node.yml which runs 1 instance for PoC purposes
- add docker-compose-dual-node.yml which runs 2 separate instances for PoC purposes
- add ormconfig-prod.json for the above instances

others
- add typeorm dependency for database interactions
- allow vscode debugging: add launch.json